### PR TITLE
Add host parameter for backends

### DIFF
--- a/cinder/files/backend/_ceph.conf
+++ b/cinder/files/backend/_ceph.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 volume_driver = cinder.volume.drivers.rbd.RBDDriver
 #

--- a/cinder/files/backend/_fujitsu.conf
+++ b/cinder/files/backend/_fujitsu.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 volume_driver=cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_fc.FJDXFCDriver
 cinder_eternus_config_file=/etc/cinder/cinder_fujitsu_eternus_dx_{{ backend_name }}.xml

--- a/cinder/files/backend/_gpfs.conf
+++ b/cinder/files/backend/_gpfs.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 volume_driver = cinder.volume.drivers.ibm.gpfs.GPFSDriver
 gpfs_mount_point_base={{ backend.mount_point }}

--- a/cinder/files/backend/_hitachi_vsp.conf
+++ b/cinder/files/backend/_hitachi_vsp.conf
@@ -1,6 +1,6 @@
 
 [{{ backend_name }}]
-
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 volume_driver = cinder.volume.drivers.hitachi.hbsd.hbsd_fc.HBSDFCDriver
 

--- a/cinder/files/backend/_hp3par.conf
+++ b/cinder/files/backend/_hp3par.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 hp3par_api_url={{ backend.url }}
 

--- a/cinder/files/backend/_hp_lefthand.conf
+++ b/cinder/files/backend/_hp_lefthand.conf
@@ -1,4 +1,5 @@
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 hplefthand_api_url={{ backend.api_url }}
 

--- a/cinder/files/backend/_lvm.conf
+++ b/cinder/files/backend/_lvm.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver
 volume_backend_name={{ backend_name }}
 lvm_type = default

--- a/cinder/files/backend/_solidfire.conf
+++ b/cinder/files/backend/_solidfire.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_backend_name={{ backend_name }}
 san_ip={{ backend.san_ip }}
 san_login={{ backend.san_login }}

--- a/cinder/files/backend/_storwize.conf
+++ b/cinder/files/backend/_storwize.conf
@@ -1,5 +1,6 @@
 
 [{{ backend_name }}]
+host={{ backend.get('host', grains.host) }}
 volume_driver = cinder.volume.drivers.ibm.storwize_svc.StorwizeSVCDriver
 volume_backend_name={{ backend_name }}
 san_ip={{ backend.host }}


### PR DESCRIPTION
When cinder-volume & cinder-scheduler are shutdown on ctl-0x, we can't
add/remove volumes which are linked to specific service.