### PR TITLE
Parameterize option rbd_flatten_volume_from_snapshot.

### DIFF
--- a/cinder/files/backend/_ceph.conf
+++ b/cinder/files/backend/_ceph.conf
@@ -22,6 +22,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ backend.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/backend/_ceph.conf
+++ b/cinder/files/backend/_ceph.conf
@@ -22,7 +22,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ backend.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ backend.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/juno/cinder.conf.controller.Debian
+++ b/cinder/files/juno/cinder.conf.controller.Debian
@@ -265,7 +265,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/juno/cinder.conf.controller.Debian
+++ b/cinder/files/juno/cinder.conf.controller.Debian
@@ -265,7 +265,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/juno/cinder.conf.controller.Debian
+++ b/cinder/files/juno/cinder.conf.controller.Debian
@@ -265,6 +265,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/juno/cinder.conf.volume.Debian
+++ b/cinder/files/juno/cinder.conf.volume.Debian
@@ -329,6 +329,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/juno/cinder.conf.volume.Debian
+++ b/cinder/files/juno/cinder.conf.volume.Debian
@@ -329,7 +329,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/kilo/cinder.conf.controller.Debian
+++ b/cinder/files/kilo/cinder.conf.controller.Debian
@@ -302,7 +302,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/kilo/cinder.conf.controller.Debian
+++ b/cinder/files/kilo/cinder.conf.controller.Debian
@@ -302,6 +302,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/kilo/cinder.conf.volume.Debian
+++ b/cinder/files/kilo/cinder.conf.volume.Debian
@@ -366,6 +366,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/kilo/cinder.conf.volume.Debian
+++ b/cinder/files/kilo/cinder.conf.volume.Debian
@@ -366,7 +366,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/liberty/cinder.conf.controller.Debian
+++ b/cinder/files/liberty/cinder.conf.controller.Debian
@@ -315,6 +315,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/liberty/cinder.conf.controller.Debian
+++ b/cinder/files/liberty/cinder.conf.controller.Debian
@@ -315,7 +315,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ controller.storage.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/liberty/cinder.conf.volume.Debian
+++ b/cinder/files/liberty/cinder.conf.volume.Debian
@@ -360,6 +360,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)

--- a/cinder/files/liberty/cinder.conf.volume.Debian
+++ b/cinder/files/liberty/cinder.conf.volume.Debian
@@ -360,7 +360,7 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 # Flatten volumes created from snapshots to remove dependency
 # from volume to snapshot (boolean value)
 #rbd_flatten_volume_from_snapshot=false
-rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', 'false') }}
+rbd_flatten_volume_from_snapshot={{ volume.storage.get('flatten_volume_from_snapshot', False)|lower }}
 
 # The libvirt uuid of the secret for the rbd_user volumes
 # (string value)


### PR DESCRIPTION
Usecase is to be able to modify `cinder.conf` parameter `rbd_flatten_volume_from_snapshot` via reclass definition file.