### PR TITLE
Add Cinder Block Device driver backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -466,6 +466,23 @@ Cinder setup with Solidfire
             clustername: cluster1
             sf_emulate_512: false
 
+Cinder setup with Block Device driver
+
+.. code-block:: yaml
+
+    cinder:
+      volume:
+        enabled: true
+        backend:
+          bdd:
+            engine: bdd
+            enabled: true
+            type_name: bdd
+            devices:
+              - sdb
+              - sdc
+              - sdd
+
 Enable cinder-backup service for ceph
 
 .. code-block:: yaml

--- a/cinder/files/backend/_bdd.conf
+++ b/cinder/files/backend/_bdd.conf
@@ -1,0 +1,7 @@
+
+[{{ backend_name }}]
+available_devices = {% for device in backend.devices %}/dev/{{ device }}{% if not loop.last %},{% endif %}{% endfor %}
+enable_unsupported_driver = {{ backend.enabled }}
+storage_availability_zone = {{ grains.host }}
+volume_backend_name = {{ backend_name }}
+volume_driver = cinder.volume.drivers.block_device.BlockDeviceDriver

--- a/cinder/files/newton/cinder.conf.volume.Debian
+++ b/cinder/files/newton/cinder.conf.volume.Debian
@@ -141,7 +141,7 @@ memcached_servers={%- for member in volume.cache.members %}{{ member.host }}:112
 auth_version = v3
 
 [barbican]
-auth_endpoint=http://{{ controller.identity.host }}:5000
+auth_endpoint=http://{{ volume.identity.host }}:5000
 
 [database]
 idle_timeout=3600

--- a/cinder/files/ocata/cinder.conf.volume.Debian
+++ b/cinder/files/ocata/cinder.conf.volume.Debian
@@ -141,7 +141,7 @@ memcached_servers={%- for member in volume.cache.members %}{{ member.host }}:112
 auth_version = v3
 
 [barbican]
-auth_endpoint=http://{{ controller.identity.host }}:5000
+auth_endpoint=http://{{ volume.identity.host }}:5000
 
 [database]
 idle_timeout=3600


### PR DESCRIPTION
- Fix issue if we want to deploy cinder-volume on non-controller nodes
- Add Cinder Block Device driver backend 