### PR TITLE
Add enable_force_upload parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ cinder-volume to role volume.
         cinder_uid: 304
         cinder_gid: 304
         default_volume_type: 7k2SaS
+        enable_force_upload: true
         availability_zone_fallback: True
         database:
           engine: mysql
@@ -55,7 +56,7 @@ cinder-volume to role volume.
             multihost: true
             multipath: true
             pool: SAS7K2
-        audit: 
+        audit:
           enabled: false
         osapi_max_limit: 500
 
@@ -66,6 +67,7 @@ cinder-volume to role volume.
         cinder_uid: 304
         cinder_gid: 304
         default_volume_type: 7k2SaS
+        nable_force_upload: true
         database:
           engine: mysql
           host: 127.0.0.1
@@ -430,7 +432,7 @@ Cinder setup with IBM GPFS filesystem
             type_name: GPFS-SILVER
             engine: gpfs
             mount_point: '/mnt/gpfs-openstack/cinder/silver'
-  
+
 Cinder setup with HP LeftHand
 
 .. code-block:: yaml
@@ -452,7 +454,7 @@ Extra parameters for HP LeftHand
 
 .. code-block:: yaml
 
-    cinder type-key normal-storage set hplh:data_pl=r-10-2 hplh:provisioning=full 
+    cinder type-key normal-storage set hplh:data_pl=r-10-2 hplh:provisioning=full
 
 Cinder setup with Solidfire
 
@@ -517,7 +519,7 @@ Enable cinder-backup service for ceph
           ceph_user: cinder
           ceph_chunk_size: 134217728
           restore_discard_excess_bytes: false
-          
+
 Enable auditing filter, ie: CADF
 
 .. code-block:: yaml

--- a/cinder/files/liberty/cinder.conf.controller.Debian
+++ b/cinder/files/liberty/cinder.conf.controller.Debian
@@ -71,6 +71,10 @@ storage_availability_zone={{controller.storage_availability_zone}}
 default_availability_zone={{controller.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/liberty/cinder.conf.controller.Debian
+++ b/cinder/files/liberty/cinder.conf.controller.Debian
@@ -74,7 +74,7 @@ default_availability_zone={{controller.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ controller.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/liberty/cinder.conf.volume.Debian
+++ b/cinder/files/liberty/cinder.conf.volume.Debian
@@ -60,7 +60,7 @@ default_availability_zone={{volume.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ volume.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/liberty/cinder.conf.volume.Debian
+++ b/cinder/files/liberty/cinder.conf.volume.Debian
@@ -57,6 +57,10 @@ storage_availability_zone={{volume.storage_availability_zone}}
 default_availability_zone={{volume.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/mitaka/cinder.conf.controller.Debian
+++ b/cinder/files/mitaka/cinder.conf.controller.Debian
@@ -59,6 +59,10 @@ storage_availability_zone={{controller.storage_availability_zone}}
 default_availability_zone={{controller.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/mitaka/cinder.conf.controller.Debian
+++ b/cinder/files/mitaka/cinder.conf.controller.Debian
@@ -62,7 +62,7 @@ default_availability_zone={{controller.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ controller.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/mitaka/cinder.conf.volume.Debian
+++ b/cinder/files/mitaka/cinder.conf.volume.Debian
@@ -50,6 +50,10 @@ storage_availability_zone={{volume.storage_availability_zone}}
 default_availability_zone={{volume.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/mitaka/cinder.conf.volume.Debian
+++ b/cinder/files/mitaka/cinder.conf.volume.Debian
@@ -53,7 +53,7 @@ default_availability_zone={{volume.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ volume.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/newton/cinder.conf.controller.Debian
+++ b/cinder/files/newton/cinder.conf.controller.Debian
@@ -63,7 +63,7 @@ default_availability_zone={{controller.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ controller.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/newton/cinder.conf.controller.Debian
+++ b/cinder/files/newton/cinder.conf.controller.Debian
@@ -60,6 +60,10 @@ storage_availability_zone={{controller.storage_availability_zone}}
 default_availability_zone={{controller.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/newton/cinder.conf.volume.Debian
+++ b/cinder/files/newton/cinder.conf.volume.Debian
@@ -60,7 +60,7 @@ default_availability_zone={{volume.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ volume.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/newton/cinder.conf.volume.Debian
+++ b/cinder/files/newton/cinder.conf.volume.Debian
@@ -57,6 +57,10 @@ storage_availability_zone={{volume.storage_availability_zone}}
 default_availability_zone={{volume.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/ocata/cinder.conf.controller.Debian
+++ b/cinder/files/ocata/cinder.conf.controller.Debian
@@ -63,7 +63,7 @@ default_availability_zone={{controller.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ controller.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/ocata/cinder.conf.controller.Debian
+++ b/cinder/files/ocata/cinder.conf.controller.Debian
@@ -60,6 +60,10 @@ storage_availability_zone={{controller.storage_availability_zone}}
 default_availability_zone={{controller.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ controller.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/ocata/cinder.conf.volume.Debian
+++ b/cinder/files/ocata/cinder.conf.volume.Debian
@@ -60,7 +60,7 @@ default_availability_zone={{volume.default_availability_zone}}
 # Enables the Force option on upload_to_image. This enables running
 # upload_volume on in-use volumes for backends that support it. (boolean value)
 #enable_force_upload = false
-{{ volume.get('enable_force_upload', False)|lower }}
+enable_force_upload = {{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600

--- a/cinder/files/ocata/cinder.conf.volume.Debian
+++ b/cinder/files/ocata/cinder.conf.volume.Debian
@@ -57,6 +57,10 @@ storage_availability_zone={{volume.storage_availability_zone}}
 default_availability_zone={{volume.default_availability_zone}}
 {%- endif %}
 
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+{{ volume.get('enable_force_upload', False)|lower }}
 
 #RPC response timeout recommended by Hitachi
 rpc_response_timeout=3600


### PR DESCRIPTION
Parametrize enable_force_upload option introduced in Liberty release. This option enables running upload_volume on in-use volumes for backends that support it. 