### PR TITLE
Use backend_host for ceph backends, to join hosts into one single entity

### DIFF
--- a/cinder/files/backend/_ceph.conf
+++ b/cinder/files/backend/_ceph.conf
@@ -1,6 +1,10 @@
 
 [{{ backend_name }}]
+{%- if backend.get('backend_host', False) %}
+backend_host={{ backend.backend_host }}
+{%- else %}
 host={{ backend.get('host', grains.host) }}
+{%- endif %}
 volume_backend_name={{ backend_name }}
 volume_driver = cinder.volume.drivers.rbd.RBDDriver
 #


### PR DESCRIPTION
In Pike the host flag is not picked up anymore, but backend_host is probably the better way to go anyway.