### PR TITLE
Image-Volume cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,6 +446,7 @@ Volume vmware related options:
               secret_uuid: da74ccb7-aa59-1721-a172-0006b1aa4e3e
               client_cinder_key: AQDOavlU6BsSJhAAnpFR906mvdgdfRqLHwu0Uw==
               report_discard_supported: True
+              image_volume_cache_enabled: False
 
   .. note:: `Ceph official documentation <http://ceph.com/docs/master/rbd/rbd-openstack/>`__
 

--- a/cinder/files/backend/_ceph.conf
+++ b/cinder/files/backend/_ceph.conf
@@ -57,3 +57,7 @@ rbd_secret_uuid={{ backend.secret_uuid }}
 # client directly, it will only notify that it can be used. (boolean value)
 #report_discard_supported = false
 report_discard_supported={{ backend.get('report_discard_supported', False)|lower }}
+
+# Enable the image volume cache for this backend. (boolean value)
+#image_volume_cache_enabled = false
+image_volume_cache_enabled={{ backend.get('image_volume_cache_enabled', False)|lower }}

--- a/tests/pillar/ceph_single.sls
+++ b/tests/pillar/ceph_single.sls
@@ -11,6 +11,7 @@ cinder:
         user: cinder
         secret_uuid: password
         client_cinder_key: password
+        image_volume_cache_enabled: true
     identity:
       engine: keystone
       host: 127.0.0.1


### PR DESCRIPTION
Introduce `image_volume_cache_enabled` parameter for ceph backend.

Optional parameter for enabling cinder image-volume cache.
By default set to false.

Local kitchen test passed.

Docs: https://docs.openstack.org/cinder/latest/admin/blockstorage-image-volume-cache.html

Hi @epcim @Martin819 Could you please look into this PR? Thanks.